### PR TITLE
Fix schema to allow duplicate habit names

### DIFF
--- a/db/schemas.js
+++ b/db/schemas.js
@@ -20,7 +20,7 @@ const habitSchema = new Schema({
   // If it is a problem, consider using the habitList array.
   // If the habit exists in the habitList array,
   // don't allow the user to create a new habit.
-  habit: {type: String, unique: true}, // e.g., smoking.
+  habit: {type: String}, // e.g., smoking.
   limit: Number,
   unit: String, // e.g., cigars.
   timeframe: String, // e.g., day / week / month


### PR DESCRIPTION
This is necessary to allow users to signup without predefining a
habit. Otherwise, null habits on new users will not be unique,
resulting in a dabatase error.